### PR TITLE
opentelemetry-instrumentation-asyncio v0.64b0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Package license: Apache-2.0
 
 Summary: OpenTelemetry instrumentation for asyncio
 
+Development: https://github.com/open-telemetry/opentelemetry-python-contrib
+
+OpenTelemetry instrumentation for asyncio
+
 Current build status
 ====================
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -2,29 +2,30 @@
 schema_version: 1
 
 context:
-  name: opentelemetry-instrumentation-asyncio
-  version: "0.63b1"
+  version: "0.64b0"
 
 package:
-  name: ${{ name|lower }}
+  name: opentelemetry-instrumentation-asyncio
   version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/opentelemetry_instrumentation_asyncio-${{ version }}.tar.gz
-  sha256: 0ae623583dcbe0ae17d63c995906d02a64213652ff180875ace680d1e6c286ec
+  url: 
+    https://pypi.org/packages/source/o/opentelemetry-instrumentation-asyncio/opentelemetry_instrumentation_asyncio-${{
+    version }}.tar.gz
+  sha256: 6e46bd971b091aa0ba64ebf2358e8cb3b6052a2f12cea30c73cc0d527ffca2c1
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python ${{ python_min }}.*
-    - hatchling
     - pip
+    - hatchling
   run:
-    - python >=${{ python_min }},<4.0
+    - python >=${{ python_min }}
     - opentelemetry-api >=1.14,<2.dev0
     - opentelemetry-instrumentation ==${{ version }}
     - opentelemetry-semantic-conventions ==${{ version }}
@@ -33,16 +34,22 @@ requirements:
 tests:
   - python:
       imports:
-        - opentelemetry
-        - opentelemetry.instrumentation.asyncio
+       - opentelemetry
+       - opentelemetry.instrumentation.asyncio
       pip_check: true
-      python_version: ${{ python_min }}.*
+      python_version:
+        - ${{ python_min }}.*
+        - "*"
 
 about:
-  summary: OpenTelemetry instrumentation for asyncio
-  homepage: https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncio
+  homepage: 
+    https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/instrumentation/opentelemetry-instrumentation-asyncio
   license: Apache-2.0
   license_file: LICENSE
+  summary: OpenTelemetry instrumentation for asyncio
+  description: |
+    OpenTelemetry instrumentation for asyncio
+  repository: https://github.com/open-telemetry/opentelemetry-python-contrib
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
- opentelemetry-instrumentation-asyncio 0.63b1 -> 0.64b0
- recipe refreshed to current CFE local shape; built + tested locally with rattler-build before this PR